### PR TITLE
Add focus level persistence

### DIFF
--- a/ArducamCameraControl/static/js/ArducamCameraControl.js
+++ b/ArducamCameraControl/static/js/ArducamCameraControl.js
@@ -96,6 +96,11 @@ $(function() {
                 $('#ircut').attr('disabled',true);
             })
 
+            // Set Focus slider to last-saved focus level
+            self.sendReq("get_focus", 0, function(c) {
+                $('#control-ptz-focus').val(c);
+            }, function() {})
+
             self.sendReq("paramme", 0, function() {
 
             })


### PR DESCRIPTION
Adds persistence to the camera focus level so that the focus persists across OctoPrint restarts and system power cycles.  This is necessary for cameras that control focus electromagnetically, otherwise they reset position upon power off.